### PR TITLE
[docs] Upgrade base-z dependency for autodoc updates

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.14.1",
     .dependencies = .{
         .base = .{
-            .hash = "base-0.1.0-rhH4pmk0BQDIWjxXCQWPojOa8eDb4iFVM4qVE5IT9yTt",
-            .url = "git+https://github.com/kofi-q/base-z.git#71b4ca6731ed478e3356421f35fc712cd043ae6a",
+            .hash = "base-0.1.0-rhH4ppUoBQBUYC5OJ5Ncghnvt8bn8i2QJa18QxXowF_X",
+            .url = "git+https://github.com/kofi-q/base-z.git#032c4f016efc277a4705a6730d693635a4c00831",
         },
     },
     .paths = .{


### PR DESCRIPTION
Docs builds are running against nightly Zig, so [updates were needed](https://github.com/kofi-q/base-z/pull/1) to handle the recent breaking syntax and writer interface changes. Might eventually spin off a 0.14.1 branch in the `base-z` dep to enable building with 0.14.1 until 0.15.0 is released.