### PR TITLE
[zig 0.15.0] Update callconv(.C) -> callconv(.c)

### DIFF
--- a/src/async/threadsafe_fn.zig
+++ b/src/async/threadsafe_fn.zig
@@ -164,7 +164,7 @@ pub fn wrapCallback(
     };
 
     const Handler = struct {
-        fn cb(opt_env: ?Env, _: ?Val, ctx: Ctx, arg: Arg) callconv(.C) void {
+        fn cb(opt_env: ?Env, _: ?Val, ctx: Ctx, arg: Arg) callconv(.c) void {
             // This is null if the Node env is in the process of getting
             // unloaded. If that's the case, nothing to do here.
             const env = opt_env orelse return;
@@ -216,7 +216,7 @@ pub fn wrapProxy(
             cb_js_opt: ?Val,
             ctx: Ctx,
             arg: Arg,
-        ) callconv(.C) void {
+        ) callconv(.c) void {
             // These are null if the Node env is in the process of getting
             // unloaded. If that's the case, nothing to do here.
             const env = env_opt orelse return;

--- a/src/async/worker.zig
+++ b/src/async/worker.zig
@@ -65,7 +65,7 @@ pub fn ExecuteT(comptime Ctx: type) type {
 
 pub fn wrapExecute(comptime func: Execute) n.AsyncExecute {
     const Cb = struct {
-        fn proxy(env: Env, _: ?AnyPtr) callconv(.C) void {
+        fn proxy(env: Env, _: ?AnyPtr) callconv(.c) void {
             func() catch |err| switch (err) {
                 Err.PendingException => {},
                 else => env.throwOrPanic(.{
@@ -87,7 +87,7 @@ pub fn wrapExecuteT(
     comptime func: ExecuteT(Ctx),
 ) n.AsyncExecute {
     const Cb = struct {
-        fn proxy(env: Env, ctx: ?Ctx) callconv(.C) void {
+        fn proxy(env: Env, ctx: ?Ctx) callconv(.c) void {
             @call(.always_inline, func, .{ctx.?}) catch |err| switch (err) {
                 Err.PendingException => {},
                 else => env.throwOrPanic(.{
@@ -107,7 +107,7 @@ pub fn wrapExecuteT(
 
 pub fn wrapComplete(comptime func: Complete) n.AsyncComplete {
     const Cb = struct {
-        fn proxy(env: Env, status: n.Status, _: ?AnyPtr) callconv(.C) void {
+        fn proxy(env: Env, status: n.Status, _: ?AnyPtr) callconv(.c) void {
             @call(.always_inline, func, .{
                 env, status.check(),
             }) catch |err| switch (err) {
@@ -131,7 +131,7 @@ pub fn wrapCompleteT(
     comptime func: CompleteT(Ctx),
 ) n.AsyncComplete {
     const Cb = struct {
-        fn proxy(env: Env, status: n.Status, ctx: ?Ctx) callconv(.C) void {
+        fn proxy(env: Env, status: n.Status, ctx: ?Ctx) callconv(.c) void {
             @call(.always_inline, func, .{
                 ctx.?, env, status.check(),
             }) catch |err| switch (err) {

--- a/src/function/callback.zig
+++ b/src/function/callback.zig
@@ -61,7 +61,7 @@ pub fn napiCb(comptime impl: anytype, comptime opts: CbOptions) n.Callback {
     };
 
     return struct {
-        pub fn proxy(env: Env, info: n.CallInfo) callconv(.C) ?Val {
+        pub fn proxy(env: Env, info: n.CallInfo) callconv(.c) ?Val {
             var buf_err: [128]u8 = undefined;
 
             const call = CallResolved{ .env = env, .info = info };

--- a/src/root.zig
+++ b/src/root.zig
@@ -288,11 +288,11 @@ pub fn exportModuleWithInit(
     comptime init_fn: ?InitFn,
 ) void {
     const entry_points = struct {
-        fn apiVersion() callconv(.C) NapiVersion {
+        fn apiVersion() callconv(.c) NapiVersion {
             return options.napi_version;
         }
 
-        fn registerModule(env: Env, mod_js: Val) callconv(.C) ?Val {
+        fn registerModule(env: Env, mod_js: Val) callconv(.c) ?Val {
             const exports = defineExports(env, mod_js, mod) orelse return null;
 
             const override: ?Val = blk: {


### PR DESCRIPTION
Updates for compatibility with both Zig 0.14.1 and 0.15.0 (as of 07/20).