### PR TITLE
[zig-v0.15] Switch "Async" namespace to lowercase "async"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ comptime {
 
 pub fn hello(name: tokota.TinyStr(16)) ![]const u8 {
     var buf: [32]u8 = undefined;
-    return std.fmt.bufPrint(&buf, "{}, how be?", .{name});
+    return std.fmt.bufPrint(&buf, "{f}, how be?", .{name});
 }
 
 pub fn add(a: i32, b: i32) i32 {

--- a/examples/async/extended.zig
+++ b/examples/async/extended.zig
@@ -27,7 +27,7 @@ pub fn todosForUser(call: t.Call, user_id: u32, limit: u32) !t.Promise {
 const Runner = struct {
     arena: std.heap.ArenaAllocator,
     limit: usize,
-    task: t.Async.Task(*@This()),
+    task: t.async.Task(*@This()),
     user_id: u32,
 
     const Todo = struct {

--- a/examples/async/minimal.zig
+++ b/examples/async/minimal.zig
@@ -20,7 +20,7 @@ pub fn todoTotals(call: t.Call) !t.Promise {
 /// Exposes async callbacks required by `Env.asyncTask()` for executing
 /// and settling the `Promise`.
 const Runner = struct {
-    task: t.Async.Task(*@This()),
+    task: t.async.Task(*@This()),
 
     const Todo = struct { completed: bool };
     const Totals = struct { completed: u32, pending: u32 };

--- a/src/async/Env.zig
+++ b/src/async/Env.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 
-const Async = @import("../root.zig").Async;
+const async = @import("../root.zig").async;
 const Deferred = @import("promise.zig").Deferred;
 const Env = @import("../root.zig").Env;
 const n = @import("../napi.zig");
@@ -93,7 +93,7 @@ const wrapExecuteT = @import("worker.zig").wrapExecuteT;
 /// const Generator = struct {
 ///     buf: [255]u8,
 ///     len: u8,
-///     task: t.Async.Task(*@This()),
+///     task: t.async.Task(*@This()),
 ///
 ///     pub fn execute(self: *Generator) ![]u8 {
 ///         if (self.len < 64) return error.NeedMoreBytes;
@@ -141,17 +141,17 @@ const wrapExecuteT = @import("worker.zig").wrapExecuteT;
 pub fn asyncTask(
     self: Env,
     executor_ptr: anytype,
-    task: *Async.Task(@TypeOf(executor_ptr)),
+    task: *async.Task(@TypeOf(executor_ptr)),
 ) !Promise {
-    const Task = Async.Task(@TypeOf(executor_ptr));
+    const Task = async.Task(@TypeOf(executor_ptr));
 
     const prom, const deferred = try self.promise();
 
-    var async_work: ?Async.Worker = undefined;
+    var async_work: ?async.Worker = undefined;
     try n.napi_create_async_work(
         self,
         prom.ptr,
-        try Async.Resource.default.nameVal(self),
+        try async.Resource.default.nameVal(self),
         @ptrCast(&Task.execute),
         @ptrCast(&Task.complete),
         task,
@@ -176,12 +176,12 @@ pub fn asyncTask(
 /// https://nodejs.org/docs/latest/api/n-api.html#napi_create_async_work
 pub fn asyncWorker(
     self: Env,
-    comptime execute: Async.Execute,
-    comptime complete: Async.Complete,
-    resource: ?Async.Resource,
-) !Async.Worker {
-    const async_resource = resource orelse Async.Resource.default;
-    var ptr: ?Async.Worker = null;
+    comptime execute: async.Execute,
+    comptime complete: async.Complete,
+    resource: ?async.Resource,
+) !async.Worker {
+    const async_resource = resource orelse async.Resource.default;
+    var ptr: ?async.Worker = null;
     try n.napi_create_async_work(
         self,
         async_resource.ptr,
@@ -199,14 +199,14 @@ pub fn asyncWorker(
 pub fn asyncWorkerT(
     self: Env,
     ctx: anytype,
-    comptime execute: Async.ExecuteT(@TypeOf(ctx)),
-    comptime complete: Async.CompleteT(@TypeOf(ctx)),
-    resource: ?Async.Resource,
-) !Async.Worker {
+    comptime execute: async.ExecuteT(@TypeOf(ctx)),
+    comptime complete: async.CompleteT(@TypeOf(ctx)),
+    resource: ?async.Resource,
+) !async.Worker {
     const T = @TypeOf(ctx);
-    const async_resource = resource orelse Async.Resource.default;
+    const async_resource = resource orelse async.Resource.default;
 
-    var ptr: ?Async.Worker = null;
+    var ptr: ?async.Worker = null;
     try n.napi_create_async_work(
         self,
         async_resource.ptr,

--- a/src/async/napi.zig
+++ b/src/async/napi.zig
@@ -15,7 +15,7 @@ pub const AsyncContext = *const opaque {};
 /// https://nodejs.org/docs/latest/api/n-api.html#napi_async_execute_callback
 pub const AsyncExecute = *const fn (t.Env, ?t.AnyPtr) callconv(.c) void;
 
-pub const AsyncWorker = t.Async.Worker;
+pub const AsyncWorker = t.async.Worker;
 
 pub const CallbackScope = *const opaque {};
 

--- a/src/async/test.zig
+++ b/src/async/test.zig
@@ -110,7 +110,7 @@ const TaskPromise = struct {
 pub const AsyncWorker = struct {
     deferred: t.Deferred,
     input: [:0]u8,
-    work: t.Async.Worker,
+    work: t.async.Worker,
 
     fn deinit(self: *AsyncWorker, env: t.Env) void {
         const allo = dba.allocator();
@@ -134,8 +134,8 @@ pub const AsyncWorker = struct {
     fn workIt(
         env: t.Env,
         input: t.Val,
-        comptime execute_it: t.Async.ExecuteT(*AsyncWorker),
-        comptime complete_it: t.Async.CompleteT(*AsyncWorker),
+        comptime execute_it: t.async.ExecuteT(*AsyncWorker),
+        comptime complete_it: t.async.CompleteT(*AsyncWorker),
     ) !t.Promise {
         const promise, const deferred = try env.promise();
 
@@ -229,7 +229,7 @@ pub const Promises = struct {
 pub const AsyncTask = struct {
     const ExecuteOnly = struct {
         result: f64,
-        task: t.Async.Task(*@This()),
+        task: t.async.Task(*@This()),
 
         fn schedule(self: *ExecuteOnly, env: t.Env, result: f64) !t.Promise {
             self.* = .{ .result = result, .task = undefined };
@@ -249,7 +249,7 @@ pub const AsyncTask = struct {
 
     const WithComplete = struct {
         result: f64,
-        task: t.Async.Task(*@This()),
+        task: t.async.Task(*@This()),
 
         fn schedule(self: *WithComplete, env: t.Env, result: f64) !t.Promise {
             self.* = .{ .result = result, .task = undefined };
@@ -275,7 +275,7 @@ pub const AsyncTask = struct {
     const WithCleanup = struct {
         on_cleanup: t.Ref(t.Fn),
         result: f64,
-        task: t.Async.Task(*@This()),
+        task: t.async.Task(*@This()),
 
         fn schedule(self: *WithCleanup, call: t.Call) !t.Promise {
             const result, const on_cleanup = try call.argsAs(.{ f64, t.Fn });
@@ -309,7 +309,7 @@ pub const AsyncTask = struct {
 
     const WithErrConvert = struct {
         on_cleanup: t.Ref(t.Fn),
-        task: t.Async.Task(*@This()),
+        task: t.async.Task(*@This()),
 
         fn schedule(
             self: *WithErrConvert,

--- a/src/root.zig
+++ b/src/root.zig
@@ -102,7 +102,7 @@ pub const Val = @import("val.zig").Val;
 pub const ValType = @import("val.zig").ValType;
 
 /// Types related to NodeJS async operations.
-pub const Async = struct {
+pub const async = struct {
     const mod_task = @import("async/task.zig");
     const mod_work = @import("async/worker.zig");
 
@@ -114,6 +114,9 @@ pub const Async = struct {
     pub const Task = mod_task.Task;
     pub const Worker = mod_work.Worker;
 };
+
+/// Deprecated: use `async` instead.
+pub const Async = async;
 
 /// Types related to Threadsafe Functions, providing a communication channel
 /// between secondary/background threads and the main JS thread.


### PR DESCRIPTION
Since `async` is no longer a keyword,
the `Async` namespace can be lowercased
without needing to be escaped.

All is well.